### PR TITLE
Add Material Design Icons (with community icons)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ General purpose icons used everywhere.
 - ICONSVG - Quick customizable SVG icons, easily customize strokes, ends, and joins of paths. ([Website](https://iconsvg.xyz))
 - [Ion icons](https://github.com/ionic-team/ionicons#readme) - The premium icon font for Ionic Framework and web apps everywhere. ([Website](https://ionicons.com))
 - [Material design icons](https://github.com/google/material-design-icons#readme) - Material Design icons by Google. ([Website](https://material.io/tools/icons))
+- [Material Design Icons](https://github.com/Templarian/MaterialDesign) - Material Design icons from Google and the community ([Website](https://materialdesignicons.com/))
 - [Octicons](https://github.com/primer/octicons#readme) - A scalable set of icons handcrafted with <3 by GitHub. ([Website](https://octicons.github.com))
 - [Open Iconic](https://github.com/iconic/open-iconic#readme) - Open Iconic is the open source sibling of Iconic. ([Website](https://useiconic.com/open))
 - [Picon](https://github.com/yne/picon#readme) - Small ligature-based icon font and SVG. ([Website](https://yne.fr/picon))


### PR DESCRIPTION
It's a different repository with Google-Made Material Icons and Community-Made Icons. It has a lot more Icons than the Material Design website has.