### PR TITLE
Remove hericons from paid

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,6 @@ Icons made out of CSS only (that are not downloadable).
 
 Not open-source/free, but still awesome enough.
 
-- [Heroicons](https://www.heroicons.com) - Unique set of icons for your marketing website.
 - [Iconic](https://useiconic.com) - The definitive icon set designed for the modern web.
 - [Nucelo Icons](https://nucleoapp.com/premium-icons) - A premium library of SVG icons for iOS, Android & web projects.
 


### PR DESCRIPTION
While [Heroicons Classic](https://classic.heroicons.com/) is paid/not open source, the current version _is_. Heroicons is also already listed under General.