### PR TITLE
Add Car Brand Logos to Logos section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,7 @@ General purpose icons used everywhere.
 Logos of different brands or companies or technologies.
 
 - [Browser Logos](https://github.com/alrra/browser-logos#readme) - High resolution web browser logos.
+- [Car Brand Logos](https://github.com/vehiclespecs/brand-logos#readme) - 184 automotive manufacturer logos in SVG and PNG, from mass-market makes to supercar and EV-only brands. ([Website](https://vehiclespecs.io))
 - [Cryptocoins](https://github.com/AllienWorks/cryptocoins#readme) - Complete vector/webfont icon pack of your favourite cryptocurrencies.
 - [Cryptocurrency icons](https://github.com/atomiclabs/cryptocurrency-icons#readme) - A set of icons for all the main cryptocurrencies and altcoins. ([Website](http://cryptoicons.co))
 - [Dev icons](https://github.com/vorillaz/devicons#readme) - An iconic font made for developers. ([Website](http://vorillaz.github.io/devicons))


### PR DESCRIPTION
Adds Car Brand Logos to the Logos section.

A curated, open collection of 184 automotive brand logos (SVG + PNG) - covering mass-market makes, supercar marques, historical brands, and EV-only manufacturers. MIT-licensed repository structure, every file is jsDelivr CDN-ready, and a brands.json manifest maps brand name to filename for programmatic use.

This fills a gap in the Logos section, which currently covers crypto, dev-tool, and browser logos but has no automotive set. Entry placed alphabetically after Browser Logos.