### PR TITLE
Add GeoIcons to the Special section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ Logos of different brands or companies or technologies.
 
 Icons that are not general or logos, but something special.
 
-- [GeoIcons](https://github.com/getgeoicons/geoicons#readme) - Geographic map icons as tree-shakable SVG components. ([Website)(https://geoicons.io))
+- [GeoIcons](https://github.com/getgeoicons/geoicons#readme) - Geographic map icons as tree-shakable SVG components. ([Website](https://geoicons.io))
 - [Flag Kit](https://github.com/madebybowtie/FlagKit#readme) - Beautiful flag icons for usage in apps and on the web.
 - [Mapsicon](https://github.com/djaiss/mapsicon#readme) - A free collection of maps for every country in the world.
 - [IconicFonts](https://github.com/iconicFonts/iconic-fonts#readme) - Over 50 pre-patched fonts featuring 60k icons as glyphs.

--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ Logos of different brands or companies or technologies.
 
 Icons that are not general or logos, but something special.
 
-- [GeoIcons](https://github.com/getgeoicons/geoicons) - Geographic map icons as tree-shakable SVG components.
+- [GeoIcons](https://github.com/getgeoicons/geoicons#readme) - Geographic map icons as tree-shakable SVG components. ([Website)(https://geoicons.io))
 - [Flag Kit](https://github.com/madebybowtie/FlagKit#readme) - Beautiful flag icons for usage in apps and on the web.
 - [Mapsicon](https://github.com/djaiss/mapsicon#readme) - A free collection of maps for every country in the world.
 - [IconicFonts](https://github.com/iconicFonts/iconic-fonts#readme) - Over 50 pre-patched fonts featuring 60k icons as glyphs.

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ Icons that are not general or logos, but something special.
 - [Flag Kit](https://github.com/madebybowtie/FlagKit#readme) - Beautiful flag icons for usage in apps and on the web.
 - [Mapsicon](https://github.com/djaiss/mapsicon#readme) - A free collection of maps for every country in the world.
 - [IconicFonts](https://github.com/iconicFonts/iconic-fonts#readme) - Over 50 pre-patched fonts featuring 60k icons as glyphs.
-- [GeoIcons](https://geoicons.io) - Geographic map icons as tree-shakeable SVG components.
+- [GeoIcons](https://geoicons.io) - Geographic map icons as tree-shakable SVG components.
 
 ## Other
 

--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,7 @@ Icons that are not general or logos, but something special.
 - [Flag Kit](https://github.com/madebybowtie/FlagKit#readme) - Beautiful flag icons for usage in apps and on the web.
 - [Mapsicon](https://github.com/djaiss/mapsicon#readme) - A free collection of maps for every country in the world.
 - [IconicFonts](https://github.com/iconicFonts/iconic-fonts#readme) - Over 50 pre-patched fonts featuring 60k icons as glyphs.
+- [GeoIcons](https://geoicons.io) - Geographic map icons as tree-shakeable SVG components.
 
 ## Other
 

--- a/readme.md
+++ b/readme.md
@@ -66,10 +66,10 @@ Logos of different brands or companies or technologies.
 
 Icons that are not general or logos, but something special.
 
+- [GeoIcons](https://github.com/getgeoicons/geoicons) - Geographic map icons as tree-shakable SVG components.
 - [Flag Kit](https://github.com/madebybowtie/FlagKit#readme) - Beautiful flag icons for usage in apps and on the web.
 - [Mapsicon](https://github.com/djaiss/mapsicon#readme) - A free collection of maps for every country in the world.
 - [IconicFonts](https://github.com/iconicFonts/iconic-fonts#readme) - Over 50 pre-patched fonts featuring 60k icons as glyphs.
-- [GeoIcons](https://geoicons.io) - Geographic map icons as tree-shakable SVG components.
 
 ## Other
 


### PR DESCRIPTION
Adds GeoIcons to the Special section.

GeoIcons is a set of geographic map-shape icons covering every country, territory, and world region, each a tree-shakable SVG component (React, Vue, Angular, and vanilla JS), themeable with currentColor. Placed alphabetically between Flag Kit and Mapsicon.

Site: https://geoicons.io
Source: https://github.com/getgeoicons/geoicons